### PR TITLE
Dynamic detection of disks

### DIFF
--- a/framework.sh
+++ b/framework.sh
@@ -104,6 +104,25 @@ print_split() {
     printf "%-${first_half_width}s%${second_half_width}s" "$2" "$3"
 }
 
+# Prints one line of text, truncates it at specified width and add ellipsis.
+# Truncation can occur either at the start or at the end of the string.
+# $1 - line to print
+# $2 - width limit
+# $3 - "start" or "end", default "end"
+print_truncate() {
+    local out
+    local new_length=$(($2 - 1))
+    # Just echo the string if it's shorter than the limit
+    if [ ${#1} -le $2 ]; then
+        out="$1"
+    elif [ -z "$3" ] || [ "$3" = "end" ]; then
+        out="${1::$new_length}…"
+    else
+        out="…${1: -$new_length}"
+    fi
+    echo "$out"
+}
+
 # Strips ANSI color codes from given string
 # $1 - text to strip
 strip_ansi() {

--- a/modules/32-disk
+++ b/modules/32-disk
@@ -2,18 +2,28 @@
 
 source "$BASE_DIR/framework.sh"
 
-declare -A disks
-disks["Root"]="/dev/sda1"
+is_mounted()
+{
+    df -l | awk '{ print $1 }' | grep -q "${1}$"
+}
+
+disks=($(lsblk --noheadings --list --output name))
 padding=15
 
 text=""
 all_disks="$(df -h)"
 for name in "${!disks[@]}"; do
     disk="${disks[$name]}"
-    stats="$(awk -v pat="$disk" '$0~pat {print $2,$3,$4,$5}' <<< $all_disks)"
-    IFS=" " read -r total used free percentage <<< $stats
-    label="$(print_split $WIDTH "$name - $used used, $free free" "/ $total")"
-    text+="$label\n$(print_bar $WIDTH ${percentage::-1})\n"
+    device="/dev/${disk}"
+    is_mounted ${device}
+    if [ $? -eq 0 ]
+    then
+        stats="$(awk -v pat="$disk" '$0~pat {print $2,$3,$4,$5}' <<< $all_disks)"
+        IFS=" " read -r total used free percentage <<< $stats
+        mp=$(df -l --output=target ${device} | tail -n1)
+        label="$(print_split $WIDTH "${disks[name]} - mounted on ${mp} - $used used, $free free" "/ $total")"
+        text+="$label\n$(print_bar $WIDTH ${percentage::-1})\n"
+    fi
 done
 
 print_columns "Disk space" "${text::-2}"

--- a/modules/32-disk
+++ b/modules/32-disk
@@ -2,28 +2,26 @@
 
 source "$BASE_DIR/framework.sh"
 
-is_mounted()
-{
-    df -l | awk '{ print $1 }' | grep -q "${1}$"
-}
-
 disks=($(lsblk --noheadings --list --output name))
-padding=15
+all_disks_stats="$(df -h)"
 
 text=""
-all_disks="$(df -h)"
-for name in "${!disks[@]}"; do
-    disk="${disks[$name]}"
+for disk in "${disks[@]}"; do
     device="/dev/${disk}"
-    is_mounted ${device}
-    if [ $? -eq 0 ]
-    then
-        stats="$(awk -v pat="$disk" '$0~pat {print $2,$3,$4,$5}' <<< $all_disks)"
-        IFS=" " read -r total used free percentage <<< $stats
-        mp=$(df -l --output=target ${device} | tail -n1)
-        label="$(print_split $WIDTH "${disks[name]} - mounted on ${mp} - $used used, $free free" "/ $total")"
-        text+="$label\n$(print_bar $WIDTH ${percentage::-1})\n"
-    fi
+
+    grep -q "$device\s" <<< $all_disks_stats || continue
+
+    stats="$(awk -v pat="$disk" '$0~pat {print $2,$3,$4,$5,$6}' <<< $all_disks_stats)"
+    IFS=" " read -r total used free percentage mountpoint <<< $stats
+
+    left_label="$disk () - $used used, $free free"
+    right_label="/ $total"
+    free_width=$(( $WIDTH - ${#left_label} - ${#right_label} - 1 ))
+    mountpoint=$(print_truncate "$mountpoint" $free_width "start")
+    left_label="$disk ($mountpoint) - $used used, $free free"
+
+    label="$(print_split $WIDTH "$left_label" "$right_label")"
+    text+="$label\n$(print_bar $WIDTH ${percentage::-1})\n"
 done
 
 print_columns "Disk space" "${text::-2}"

--- a/motd.sh
+++ b/motd.sh
@@ -8,7 +8,7 @@ export CE="\e[31m"  # Error
 export CN="\e[0m"   # None
 
 # Max width used for components in second column
-export WIDTH=50
+export WIDTH=80
 
 # Don't change! We want predictable outputs
 export LANG="en_US.UTF-8"

--- a/motd.sh
+++ b/motd.sh
@@ -8,7 +8,7 @@ export CE="\e[31m"  # Error
 export CN="\e[0m"   # None
 
 # Max width used for components in second column
-export WIDTH=80
+export WIDTH=50
 
 # Don't change! We want predictable outputs
 export LANG="en_US.UTF-8"


### PR DESCRIPTION
Updated disk module to detect block devices instead of only reporting
sda. It will now enumerate all local block devices. If they are mounted
they will be included in the motd. In lieu the hardcoded "Root" for sda1
it will now report the mount point of each device.