### PR TITLE
motd.sh will parse for module files starting with a two digit number …

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,7 @@ cp config.sh.example config.sh
 To add a new module you can create a new script in `modules` directory.
 For the output to be properly formatted it has to use `print_columns` function from `framework.sh`, please refer to the existing modules.
 
+Module files have to start with a two digit number followed by a hyphen. You may disable modules by simply rename the module file.
+
 ## Credits
 Fancy MOTD is hugely inspired by [this repo](https://github.com/HermannBjorgvin/MOTD) by Hermann Björgvin.

--- a/motd.sh
+++ b/motd.sh
@@ -18,7 +18,7 @@ source "$BASE_DIR/framework.sh"
 
 # Run the modules and collect output
 output=""
-modules="$(ls -1 "$BASE_DIR/modules")"
+modules="$(ls -1 "$BASE_DIR/modules" | grep -P '^(?<!\d)\d{2}(?!\d)-')"
 while read -r module; do
     module_output="$($BASE_DIR/modules/$module 2>/dev/null)"
     [ $? -ne 0 ] && continue


### PR DESCRIPTION
…followed by a hyphen.

This way it is easy to disable modules by renaming the module file.