### PR TITLE
Switch services variable key value

### DIFF
--- a/config.sh.example
+++ b/config.sh.example
@@ -10,8 +10,8 @@ WIDTH=50
 
 # Services to show
 declare -A services
-services["nginx"]="nginx"
-services["Docker"]="docker"
-services["SSH"]="sshd"
-services["Fail2Ban"]="fail2ban"
-services["UFW"]="ufw"
+services["nginx"]="Nginx"
+services["docker"]="Docker"
+services["sshd"]="SSH"
+services["fail2ban"]="Fail2Ban"
+services["ufw"]="UFW"

--- a/modules/33-services
+++ b/modules/33-services
@@ -4,19 +4,21 @@ set -euo pipefail
 
 # Default services, have to be declared before sourcing framework.sh so the user can override them
 declare -A services
-services["nginx"]="nginx"
-services["Docker"]="docker"
-services["SSH"]="sshd"
-services["Fail2Ban"]="fail2ban"
-services["UFW"]="ufw"
+services["nginx"]="Nginx"
+services["docker"]="Docker"
+services["sshd"]="SSH"
+services["fail2ban"]="Fail2Ban"
+services["ufw"]="UFW"
 
 source "$BASE_DIR/framework.sh"
 
 statuses=()
 for key in "${!services[@]}"; do
-    # systemctl is-active returns non-zero code if service is inactive
-    set +e; status=$(systemctl is-active ${services[$key]}); set -e
-    statuses+=("$(print_status "$key" "$status")")
+    if [ $(systemctl list-unit-files "$key.service" | wc -l) -gt 3 ]; then
+        # systemctl is-active returns non-zero code if service is inactive
+        set +e; status=$(systemctl is-active $key.service); set -e
+        statuses+=("$(print_status "${services[$key]}" "$status")")
+    fi
 done
 
 text="$(print_wrap $WIDTH "${statuses[@]}")"


### PR DESCRIPTION
<https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Description>

> Valid unit names consist of a "name prefix" and a dot and a suffix specifying the unit type. The "unit prefix" must consist of one or more valid characters (ASCII letters, digits, ":", "-", "_", ".", and "\"). The total length of the unit name including the suffix must not exceed 256 characters. The type suffix must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".slice", or ".scope".

It makes more sense to have the unit name as key and as value, the name you want to display since a system unit is not allowed to have a space in its name.

---

Add an if statement so that units that do not exist are not shown. I can remove this change if you don't want it.