### PR TITLE
Support disks that don't start with "/dev"

### DIFF
--- a/modules/32-disk
+++ b/modules/32-disk
@@ -3,17 +3,20 @@
 set -euo pipefail
 source "$BASE_DIR/framework.sh"
 
-disks=($(df | grep '^/dev' | cut -d' ' -f1 | sort -u))
-all_disks_stats="$(df -h)"
+excluded_types=(
+    "devtmpfs"
+    "ecryptfs"
+    "squashfs"
+    "tmpfs"
+)
+
+disks="$(df -h --local --print-type $(printf " -x %s" "${excluded_types[@]}") | tail -n +2 | sort -u -k 7)"
 
 text=""
-for disk in "${disks[@]}"; do
-    grep -q "$disk\s" <<< $all_disks_stats || continue
+while IFS= read -r disk; do
+    IFS=" " read -r filesystem type total used free percentage mountpoint <<< $disk
 
-    stats="$(awk -v pat="$disk" '$0~pat {print $2,$3,$4,$5,$6}' <<< $all_disks_stats)"
-    IFS=" " read -r total used free percentage mountpoint <<< $stats
-
-    device="$(sed 's/\/dev//g;s/\/mapper//g;s/^.\{1\}//' <<< $disk)"
+    device="$(sed 's|/dev||g;s|/mapper||g;s|/||g' <<< $filesystem)"
     left_label="$device () - $used used, $free free"
     right_label="/ $total"
     free_width=$(( $WIDTH - ${#left_label} - ${#right_label} - 1 ))
@@ -22,6 +25,6 @@ for disk in "${disks[@]}"; do
 
     label="$(print_split $WIDTH "$left_label" "$right_label")"
     text+="$label\n$(print_bar $WIDTH ${percentage::-1})\n"
-done
+done <<< $disks
 
 print_columns "Disk space" "${text::-2}"


### PR DESCRIPTION
I'm facing the issue where currently not all my disks are shown. For example, `ZFS` pools don't start with `/dev` and are not shown. This changes the script so it filters by excluded types. The output looks exactly the same.

```bash
> df -h --local --print-type
Filesystem     Type      Size  Used Avail Use% Mounted on
devtmpfs       devtmpfs  3.2G     0  3.2G   0% /dev
tmpfs          tmpfs      32G   32K   32G   1% /dev/shm
tmpfs          tmpfs      16G  7.3M   16G   1% /run
tmpfs          tmpfs      32G  408K   32G   1% /run/wrappers
/dev/nvme0n1p2 ext4      1.8T  416G  1.3T  24% /
/dev/nvme0n1p1 vfat      511M   19M  493M   4% /boot
data           zfs       7.2T  307G  6.9T   5% /mnt/Data
tmpfs          tmpfs     6.3G   12K  6.3G   1% /run/user/1000
```

I'm not sure if there are more undesirable types.

---

cc: @brandonsdavis