### PR TITLE
Only remove '/' if it's first character of device name

### DIFF
--- a/modules/32-disk
+++ b/modules/32-disk
@@ -16,7 +16,7 @@ text=""
 while IFS= read -r disk; do
     IFS=" " read -r filesystem type total used free percentage mountpoint <<< $disk
 
-    device="$(sed 's|/dev||g;s|/mapper||g;s|/||g' <<< $filesystem)"
+    device="$(sed 's|/dev||g;s|/mapper||g;s|^/||g' <<< $filesystem)"
     left_label="$device () - $used used, $free free"
     right_label="/ $total"
     free_width=$(( $WIDTH - ${#left_label} - ${#right_label} - 1 ))


### PR DESCRIPTION
Small fix for `ZFS` pools, since datasets can have `/` in their name.

```console
> df -h --local --print-type
Filesystem     Type      Size  Used Avail Use% Mounted on
devtmpfs       devtmpfs  3.2G     0  3.2G   0% /dev
tmpfs          tmpfs      32G   32K   32G   1% /dev/shm
tmpfs          tmpfs      16G  7.3M   16G   1% /run
tmpfs          tmpfs      32G  408K   32G   1% /run/wrappers
/dev/nvme0n1p2 ext4      1.8T  405G  1.4T  24% /
/dev/nvme0n1p1 vfat      511M   37M  475M   8% /boot
tmpfs          tmpfs     6.3G     0  6.3G   0% /run/user/0
data           zfs       7.1T  256K  7.1T   1% /mnt/Data
data/backup    zfs       7.2T  129G  7.1T   2% /mnt/Data/Backup
tmpfs          tmpfs     6.3G     0  6.3G   0% /run/user/1000
```