### PR TITLE
Add ZFS ARC (cache) calculation to memory module

### DIFF
--- a/modules/32-memory
+++ b/modules/32-memory
@@ -30,7 +30,7 @@ ram() {
     usedmem=$(awk -v availmem="$availmem" '/^MemTotal:/ { print $2 - availmem }' <<< "${meminfo}")
     totalmem=$(awk '/^MemTotal:/ { print $2 }' <<< "${meminfo}")
     
-    #label display section (convered to GB)
+    #label display section
     used="$(numfmt --round=down --from-unit=1024 --to=iec <<< ${usedmem})"
     avail="$(numfmt --round=down --from-unit=1024 --to=iec <<< ${availmem})"
     total="$(numfmt --round=down --from-unit=1024 --to=iec <<< ${totalmem})"

--- a/modules/32-memory
+++ b/modules/32-memory
@@ -6,14 +6,37 @@ source "${BASE_DIR}/framework.sh"
 
 freeh=$(free -h)
 freem=$(free -m)
+meminfo=$(cat /proc/meminfo)
+
+if [ -d /proc/spl/kstat/zfs ]; then
+    # if zfs is in use on system
+    arcstat=$(cat /proc/spl/kstat/zfs/arcstats)
+    
+    arc_current=$(awk '/^size/ { print $3 / 1048576 }' <<< "${arcstat}")
+    arc_min=$(awk '/^c_min/ { print $3 / 1048576 }' <<< "${arcstat}")
+
+    # zfs arc size is dynamic, but can't shrink below the min size
+    arcsize=$(bc <<< "$arc_current-$arc_min")
+else
+    # if zfs isn't in use, set the arc to 0
+    arcsize=0
+fi
 
 ram() {
-    local memory total used available label percentage bar
-    memory=$(awk '/Mem/ {print $2,$3,$7}' <<< "${freeh}")
-    IFS=" " read -r total used available <<< "${memory}"
-    label=$(print_split "${WIDTH}" "RAM - ${used::-1} used, ${available::-1} available" "/ ${total::-1}")
+    local availmem usedmem totalmem used avail total label percentage bar
+    
+    availmem=$(awk -v arcsize="$arcsize" '/^MemAvailable:/ { print ($2 / 1024) + arcsize }' <<< "${meminfo}")
+    usedmem=$(awk -v availmem="$availmem" '/^MemTotal:/ { print ($2 / 1024) - availmem }' <<< "${meminfo}")
+    totalmem=$(awk '/^MemTotal:/ { print ($2 / 1024) }' <<< "${meminfo}")
+    
+    #label display section (convered to GB)
+    used="$(echo "scale=1; $usedmem / 1024" | bc -l)G"
+    avail="$(echo "scale=1; $availmem / 1024" | bc -l)G"
+    total="$(echo "scale=1; $totalmem / 1024" | bc -l)G"
+    label=$(print_split "${WIDTH}" "RAM - ${used} used, ${avail} available" "/ ${total}")
 
-    percentage=$(awk '/Mem/ {printf "%.0f", ($2-$7)/$2*100}' <<< "${freem}")
+    #bar display section
+    percentage=$(echo "$usedmem / $totalmem * 100" | bc -l | xargs printf %.0f)
     bar=$(print_bar "${WIDTH}" "${percentage}")
 
     printf "%s\n%s" "${label}" "${bar}"

--- a/modules/32-memory
+++ b/modules/32-memory
@@ -12,8 +12,9 @@ if [ -d /proc/spl/kstat/zfs ]; then
     # if zfs is in use on system
     arcstat=$(cat /proc/spl/kstat/zfs/arcstats)
     
-    arc_current=$(awk '/^size/ { print $3 / 1048576 }' <<< "${arcstat}")
-    arc_min=$(awk '/^c_min/ { print $3 / 1048576 }' <<< "${arcstat}")
+    # convert units to kb for easy calculation with /proc/meminfo
+    arc_current=$(awk '/^size/ { OFMT="%.0f"; print $3/1024 }' <<< "${arcstat}")
+    arc_min=$(awk '/^c_min/ { OFMT="%.0f"; print $3/1024 }' <<< "${arcstat}")
 
     # zfs arc size is dynamic, but can't shrink below the min size
     arcsize=$(bc <<< "$arc_current-$arc_min")
@@ -25,14 +26,14 @@ fi
 ram() {
     local availmem usedmem totalmem used avail total label percentage bar
     
-    availmem=$(awk -v arcsize="$arcsize" '/^MemAvailable:/ { print ($2 / 1024) + arcsize }' <<< "${meminfo}")
-    usedmem=$(awk -v availmem="$availmem" '/^MemTotal:/ { print ($2 / 1024) - availmem }' <<< "${meminfo}")
-    totalmem=$(awk '/^MemTotal:/ { print ($2 / 1024) }' <<< "${meminfo}")
+    availmem=$(awk -v arcsize="$arcsize" '/^MemAvailable:/ { print $2 + arcsize }' <<< "${meminfo}")
+    usedmem=$(awk -v availmem="$availmem" '/^MemTotal:/ { print $2 - availmem }' <<< "${meminfo}")
+    totalmem=$(awk '/^MemTotal:/ { print $2 }' <<< "${meminfo}")
     
     #label display section (convered to GB)
-    used="$(echo "scale=1; $usedmem / 1024" | bc -l)G"
-    avail="$(echo "scale=1; $availmem / 1024" | bc -l)G"
-    total="$(echo "scale=1; $totalmem / 1024" | bc -l)G"
+    used="$(numfmt --round=down --from-unit=1024 --to=iec <<< ${usedmem})"
+    avail="$(numfmt --round=down --from-unit=1024 --to=iec <<< ${availmem})"
+    total="$(numfmt --round=down --from-unit=1024 --to=iec <<< ${totalmem})"
     label=$(print_split "${WIDTH}" "RAM - ${used} used, ${avail} available" "/ ${total}")
 
     #bar display section


### PR DESCRIPTION
Hello!
This is my first PR, so please let me know if I'm doing something wrong. 

On machines with a ZFS disk being used, because of the way free memory is calculated (the cache for ZFS is separate from the normal page cache) it appears that you have less available. Some Linux tools have added the functionality to subtract this from used memory. I have added that to the memory module, and also needed to refactor the way it gets memory stats to make the calculations. 

As such, instead of using free -h, it gets the info from /proc/meminfo. I've tested this on both machines without ZFS and with, and I think it outputs identically to the previous way, with the intended behavior for machines running ZFS.